### PR TITLE
Static file support for PHP built-in webserver

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,6 +4,13 @@
  * @author Joakim Nygård
  */
 
+// Handle static files with PHP built-in webserver
+if (PHP_SAPI == 'cli-server') {
+    if (is_file(realpath(__DIR__ . $_SERVER['REQUEST_URI']))) {
+        return false;
+    }
+}
+
 class Webgrind_MasterConfig
 {
     static $webgrindVersion = '1.3';


### PR DESCRIPTION
With this addition, all of the static assets (css, js, etc.) can be served properly when running webgrind with the PHP built-in webserver. Without this fix, none of them load properly.

From within the webgrind dir, see it working with this command:
php -S 0.0.0.0:8080 -t . index.php

Thanks.
